### PR TITLE
Fix formating so the Contributors section is not part of the Guidelines section

### DIFF
--- a/proposals/0003-spec.md
+++ b/proposals/0003-spec.md
@@ -33,11 +33,11 @@ Note that the force of these words is modified by the requirement level of the d
 
 
 5. MAY – This word, or the adjective “OPTIONAL,” mean that an item is truly discretionary.
-Contributors
+
+###Contributors
 * WildFly Swarm
 * Eclipse Vert.x
-* Hawkular
-Specification
+* Hawkular Specification
 
 
 ## Rationale


### PR DESCRIPTION
The Contributors section was folded into the Guidelines section and appearing as items 6..8. This fixes that.

Signed-off-by: Scott Stark <starksm64@gmail.com>
